### PR TITLE
Update to Kotlin 1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.gradle
+local.properties
+build
+capture

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,14 +49,14 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'com.google.android.gms:play-services-tasks:17.2.0'
     // Coroutines dependencies
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1'
     // Lifecycle library
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
 
@@ -64,10 +64,11 @@ dependencies {
     // [START rx_gradle]
     // Source: https://github.com/ashdavies/rx-tasks
     implementation 'io.ashdavies.rx.rxtasks:rx-tasks:2.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$kotlin_version"
     // [END rx_gradle]
     // [START ktx_gradle]
     // Source: https://github.com/Kotlin/kotlinx.coroutines/tree/master/integration/kotlinx-coroutines-play-services
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.4.1'
     // [END ktx_gradle]
     // [START guava_gradle]
     implementation "androidx.concurrent:concurrent-futures:1.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,13 @@
  */
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.72"
+    ext.kotlin_version = "1.4.10"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.1"
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 14 10:59:44 CDT 2020
+#Fri Nov 20 09:11:31 CST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
Fixed mixed runtime dependencies onto Kotlin 1.4 and 1.3 libraries.

- The build was warning about mixing Kotlin runtime 1.3.x with 1.4.x. This turned out to be from a dependency in rx-tasks:2.2.2 onto kotlin-scripting-jvm:1.3.11. I pulled this up with an explicit dependency on kotlin-scripting-jvm:$kotlin_version.
- Updated other dependencies to Kotlin 1.4.x
